### PR TITLE
refactor: quick wins — deduplicate checkKValue, extract assayAsDF, fix qualitySet message (PR 2)

### DIFF
--- a/R/correlation.R
+++ b/R/correlation.R
@@ -20,7 +20,7 @@
 #'
 metricsCorrelations <- function(data, margins=c(0,10,9,11), getImages=TRUE) {
 
-  data <- as.data.frame(assay(data))
+  data <- assayAsDF(data)
   data <- removeNAValues(data)
   dfStats(data)
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -80,7 +80,8 @@ insertRow <- function(existingDF, newrow, r) {
 ## Checks if k is in range [2,15]
 checkKValue <- function(k) {
   if (k < 2 || k > 15) {
-    stop("k value is not in range [2,15]")
+    error=paste("k value (",k,") is not in range [2,15]", sep="")
+    stop(error)
   }
 }
 
@@ -97,6 +98,9 @@ checkDirectory <- function(path) {
 
 sample.range <- function(x) {diff(range(x))}
 sample.min <- function(x) {min(x)}
+
+# Convenience: extract the first assay of a SummarizedExperiment as a data frame
+assayAsDF <- function(data) as.data.frame(assay(data))
 
 # data: One dataframe, thus one assay
 createSE <- function(data) {

--- a/R/metricsAnalysis.R
+++ b/R/metricsAnalysis.R
@@ -15,7 +15,7 @@
 #' plotMetricsMinMax(ontMetrics)
 #'
 plotMetricsMinMax <- function(data) {
-  data <- as.data.frame(assay(data))
+  data <- assayAsDF(data)
   # Prepare data for plotting
   # Data matrix without descritive column
   matrix = data.matrix(data[,-1])
@@ -87,7 +87,7 @@ plotMetricsMinMax <- function(data) {
 #' plotMetricsBoxplot(ontMetrics)
 #'
 plotMetricsBoxplot <- function(data) {
-  data <- as.data.frame(assay(data))
+  data <- assayAsDF(data)
   num_metrics_plot=20
   data.metrics = data[,-1] # Removing Description column
 
@@ -156,7 +156,7 @@ plotMetricsBoxplot <- function(data) {
 #' plotMetricsCluster(ontMetrics, scale=TRUE)
 #'
 plotMetricsCluster <- function(data, scale=FALSE, k=NULL) {
-  data <- as.data.frame(assay(data))
+  data <- assayAsDF(data)
   data.metrics = data[,-1] # Removing Description column
   if (isTRUE(scale)) {
     data.metrics = base::scale(data.metrics)
@@ -194,7 +194,7 @@ plotMetricsCluster <- function(data, scale=FALSE, k=NULL) {
 #' plotMetricsViolin(ontMetrics)
 #'
 plotMetricsViolin <- function(data, nplots=20) {
-  data <- as.data.frame(assay(data))
+  data <- assayAsDF(data)
   data.metrics = data[,-1] # Removing Description column
   nplots=20
 
@@ -446,7 +446,7 @@ plotMetricsClusterComparison <- function(data, k.vector1, k.vector2=NULL, seed=N
     stop("k.vector1 and k.vector2 are identical")
   }
 
-  data <- as.data.frame(SummarizedExperiment::assay(data))
+  data <- assayAsDF(data)
 
   numMetrics = length(colnames(data))-1
 
@@ -730,7 +730,7 @@ annotateClustersByMetric <- function(df, k.range, bs, seed){
   if (is.null(seed)) {
     seed = pkg.env$seed
   }
-  df <- as.data.frame(assay(df))
+  df <- assayAsDF(df)
   # Create a dataframe by removing NAs from the original data.
   df_clean = na.omit(df)
 
@@ -802,7 +802,7 @@ getMetricRangeByCluster <- function(df, k.range, bs, seed) {
   if (is.null(seed)) {
     seed = pkg.env$seed
   }
-  df <- as.data.frame(assay(df))
+  df <- assayAsDF(df)
   annotated_clusters_by_metric = annotateClustersByMetric(df, k.range, bs, seed)
 
   metrics = c()
@@ -860,7 +860,7 @@ getMetricsRelevancy <- function(df, k, alpha=0, L1=NULL, seed=NULL) {
 #    alpha = 0.1
 #  }
 
-  df <- as.data.frame(assay(df))
+  df <- assayAsDF(df)
 
   if (is.null(L1)) {
     print(paste0("No L1 provided. Computing best L1 boundry with 'sparcl::KMeansSparseCluster.permute'"))
@@ -928,7 +928,7 @@ getRSKCL1Boundry <- function(df, k, clustering="kmeans", seed=NULL) {
     seed = pkg.env$seed
   }
 
-  df <- as.data.frame(assay(df))
+  df <- assayAsDF(df)
   df_data = df[-1] # Removing 'Description' column as it is not numeric
   dataMatrix = as.matrix(df_data)
   wbounds = seq(2,sqrt(ncol(dataMatrix)), len=30)
@@ -976,7 +976,7 @@ getRSKCAlpha <- function(df, k, L1, max_alpha = 0.1, seed=NULL, numCores=1) {
     seed = pkg.env$seed
   }
 
-  df <- as.data.frame(assay(df))
+  df <- assayAsDF(df)
 
   # Helper structures
   ## Structure to keep track of stability and qualit of each RSKC run.
@@ -1164,7 +1164,7 @@ ATSC <- function(data, k.range=c(2,15), bs=100, cbi="clara",
   all_metrics=TRUE
   message(paste0("Computing optimal k value with '", cbi, "'"))
 
-  data = as.data.frame(SummarizedExperiment::assay(data))
+  data = assayAsDF(data)
   # Stability indexes
   stabRange = evaluomeR::stabilityRange(data=data, cbi=cbi, k=k.range, bs=bs,
                                         all_metrics = all_metrics,

--- a/R/predictions.R
+++ b/R/predictions.R
@@ -164,7 +164,7 @@ globalMetric = function(data, k.range=c(2,15), nrep=10, criterion=c("BIC", "AIC"
     stop("Please 'nrep' parameter should be a positive integer > 1.")
   }
 
-  data = as.data.frame(SummarizedExperiment::assay(data))
+  data = assayAsDF(data)
   rownames(data) = data[, 1]
   data = data[, 2:ncol(data)]
 

--- a/R/qualityIndices.R
+++ b/R/qualityIndices.R
@@ -42,7 +42,7 @@ quality <- function(data, k=5, cbi="kmeans", getImages=FALSE,
 
   checkKValue(k)
 
-  data <- as.data.frame(assay(data))
+  data <- assayAsDF(data)
   
   if(numCores>1){
     # Parallel version
@@ -155,7 +155,7 @@ qualityRange <- function(data, k.range=c(3,5), cbi="kmeans", getImages=FALSE,
     stop("The first value of k.range cannot be greater than its second value")
   }
 
-  data <- as.data.frame(assay(data))
+  data <- assayAsDF(data)
 
   if(numCores>1){
     # Parallel version
@@ -269,14 +269,14 @@ qualitySet <- function(data, k.set=c(2,4), cbi="kmeans", all_metrics=FALSE,
   if (k.set.length == 0) {
     stop("k.set list is empty")
   } else if (k.set.length == 1) {
-    stop("k.set list contains only one element. For one K analysis use 'stability' method")
+    stop("k.set list contains only one element. For one K analysis use 'quality' method")
   }
   k.set = sort(k.set)
   for (k in k.set) {
     checkKValue(k)
   }
 
-  data <- as.data.frame(assay(data))
+  data <- assayAsDF(data)
 
   if(numCores>1){
     suppressWarnings(
@@ -1135,11 +1135,4 @@ runSilhouetteTableRange <- function(data, k.min=NULL, k.max=NULL, k.set=NULL) {
   silhouetteData[sapply(silhouetteData, is.null)] <- NULL
   names(silhouetteData) <- paste("k_", k.range, sep = "")
   return(silhouetteData)
-}
-
-checkKValue <- function(k) {
-  if (k < 2 || k > 15) {
-    error=paste("k value (",k,") is not in range [2,15]", sep="")
-    stop(error)
-  }
 }

--- a/R/stabilityIndex.R
+++ b/R/stabilityIndex.R
@@ -54,7 +54,7 @@ stability <- function(data, k=5, bs=100, cbi="kmeans",
                       getImages=FALSE, all_metrics=FALSE, seed=NULL,
                       gold_standard=NULL, numCores=1,...) {
 
-  data <- as.data.frame(assay(data))
+  data <- assayAsDF(data)
 
   checkKValue(k)
   
@@ -131,7 +131,7 @@ stabilityRange <- function(data, k.range=c(2,15), bs=100, cbi="kmeans",
   if (k.max < k.min) {
     stop("The first value of k.range cannot be greater than its second value")
   }
-  data <- as.data.frame(SummarizedExperiment::assay(data))
+  data <- assayAsDF(data)
   
   if(numCores>1){
     # Parallel version
@@ -203,7 +203,7 @@ stabilitySet <- function(data, k.set=c(2,3), bs=100, cbi="kmeans",
     checkKValue(k)
   }
 
-  data <- as.data.frame(SummarizedExperiment::assay(data))
+  data <- assayAsDF(data)
   
   if(numCores>1){
     # Parallel version


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Second PR of the evaluomeR behavior-preserving refactor plan. Three targeted fixes with no public API changes.

## Changes

### 2a — Deduplicate `checkKValue()` (`R/helpers.R`, `R/qualityIndices.R`)

Two identical definitions existed with slightly different error messages:
- `helpers.R:81` — `"k value is not in range [2,15]"` (less informative)
- `qualityIndices.R:1140` — `"k value (X) is not in range [2,15]"` (includes actual value)

Kept the more informative version in `helpers.R`; removed the duplicate from `qualityIndices.R`. No call sites change.

### 2b — Extract `assayAsDF()` internal helper (`R/helpers.R` + 5 files)

`as.data.frame(assay(data))` / `as.data.frame(SummarizedExperiment::assay(data))` appeared ~15 times across 6 files. Extracted to a one-liner in `helpers.R`:

```r
assayAsDF <- function(data) as.data.frame(assay(data))
```

Replaced all 15 occurrences. Complex sub-expressions like `as.data.frame(assay(stabData))` or `assay(getDataQualityRange(...))` are left unchanged.

### 2c — Fix copy-paste error in `qualitySet` error message (`R/qualityIndices.R`)

`qualitySet` was reporting `"use 'stability' method"` when it should say `"use 'quality' method"`. The message was a direct copy from `stabilitySet`.

### 2d — `globalMetric` NAMESPACE (already done)

The plan noted `globalMetric` was absent from NAMESPACE; it is already present at line 76. No change needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c57af5c-bc7e-4a8e-8b7f-f19e1c597d2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c57af5c-bc7e-4a8e-8b7f-f19e1c597d2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

